### PR TITLE
add asyncronous scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # blipblop
 
-This is just a demonstration of scraping with Go.  It simply fetches the Job Titles of all the positions in Leeds and prints them to stdout.
-
-### Setup
+## Requirements
 1. Make sure Go is installed (it's super easy)
-2. `go run main.go`
+2. done
 
 If you haven't used Go before, welcome to the simple life...
 
-### To use a different scraper
-`SCRAPER=apify go run main.go`
+> Mixing languages is better than writing everything in one, if and only if using only that one is likely to overcomplicate the program - Eric Steven Raymond
 
-### Contributing
+## Go Modules
+
+This is a monorepo - all root folders are seperate modules.  The **core** module is where all the 'core' Go data is stored, this should not depend on any other module.  Go modules allow us to separate dependancies between projects.  The go.mod file lists the dependancies, go automatically manages these as you import them, downloading and installing them whenever you compile or run your code.
+
+## Contributing
 Make your change in a feature branch i.e. `scraper/feature/apify-concurrent`
 
 Make sure you're code is readable and you have `go fmt` your files before pushing.

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,0 +1,3 @@
+module core
+
+go 1.17

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -3,6 +3,7 @@
 This is just a demonstration of scraping with Go.  It simply fetches the Job Titles of all the positions in Leeds and prints them to stdout.
 
 ## Run
+
 `go run main.go`
 
 ##### To use a different scraper:

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -1,0 +1,10 @@
+# Scraper
+
+This is just a demonstration of scraping with Go.  It simply fetches the Job Titles of all the positions in Leeds and prints them to stdout.
+
+## Run
+`go run main.go`
+
+##### To use a different scraper:
+
+`SCRAPER=apify go run main.go`

--- a/scraper/main.go
+++ b/scraper/main.go
@@ -12,6 +12,6 @@ func main() {
 	scraper.Singleton().Scrape(scraper.Request{
 		Country:  "GB",
 		Location: "Leeds",
-		MaxItems: 10,
+		MaxItems: 1,
 	})
 }

--- a/scraper/scraper/interface.go
+++ b/scraper/scraper/interface.go
@@ -19,6 +19,7 @@ type Request struct {
 // external dependancies.  Other implementations may use someone elses API like apify or
 // scraper.io
 type Scraper interface {
+	// Scrape blocks until the request is complete
 	Scrape(Request)
 }
 

--- a/scraper/scraper/interface.go
+++ b/scraper/scraper/interface.go
@@ -19,8 +19,10 @@ type Request struct {
 // external dependancies.  Other implementations may use someone elses API like apify or
 // scraper.io
 type Scraper interface {
-	// Scrape blocks until the request is complete
+	// Scrape blocks until scraping is complete
 	Scrape(Request)
+	// GoScrape adds the request to be scraped and executes asyncronously
+	GoScrape(Request)
 }
 
 type ScraperType string

--- a/scraper/scraper/naive.go
+++ b/scraper/scraper/naive.go
@@ -9,32 +9,70 @@ import (
 
 // There should always be a naive implementation that we can test locally
 // with no external dependancies.
+//
+// Do not use this scraper if performance is important, it's not fast.
+// We can make a faster one ourselves with raw GoQuery or just use another
+// implementation (apify)
 type naiveScraper struct {
 	*colly.Collector
 	url string
 }
 
 func (s *naiveScraper) Scrape(req Request) {
+	c := s.Clone()
+	registerDefaultTriggers(c)
+	s.scrape(c, req)
+}
+
+func (s *naiveScraper) GoScrape(req Request) {
+	c := s.Clone()
+	c.Async = true
+	registerDefaultTriggers(c)
+	s.scrape(c, req)
+}
+
+func (s *naiveScraper) scrape(c *colly.Collector, req Request) {
+	// This channel allows us to quit scraping prematurely
+	quit := make(chan bool)
+
+	// Callbacks
+	c.OnRequest(func(r *colly.Request) {
+		// If we have exceeded MaxItems then quit scraping
+		if req.MaxItems < 0 {
+			quit <- true
+		}
+	})
+	c.OnResponse(func(r *colly.Response) {
+		req.MaxItems--
+	})
+
+	// Start scraping
+	go func() {
+		c.Visit(s.url)
+		quit <- true
+	}()
+
+	// This will block until c.Visit() returns or MaxItems is exceeded
+	<-quit
+}
+
+// This is the 'logic' of the scraper,
+// defining the behaviour when elements are found on the page
+func registerDefaultTriggers(c *colly.Collector) {
 	// Find each job result link
-	s.OnHTML(`.result`, func(e *colly.HTMLElement) {
-		s.Visit(e.Request.AbsoluteURL(e.Attr("href")))
+	c.OnHTML(`.result`, func(e *colly.HTMLElement) {
+		c.Visit(e.Request.AbsoluteURL(e.Attr("href")))
 	})
 
 	// Follow through to next page
-	s.OnHTML(`a[aria-label="Next"]`, func(e *colly.HTMLElement) {
-		s.Visit(e.Request.AbsoluteURL(e.Attr("href")))
+	c.OnHTML(`a[aria-label="Next"]`, func(e *colly.HTMLElement) {
+		c.Visit(e.Request.AbsoluteURL(e.Attr("href")))
 	})
 
 	// Print the Title of the Job
-	s.OnHTML(`.jobsearch-JobInfoHeader-title`, func(e *colly.HTMLElement) {
+	c.OnHTML(`.jobsearch-JobInfoHeader-title`, func(e *colly.HTMLElement) {
 		fmt.Printf("Job Found: %s\n", e.Text)
 	})
-
-	// Callback before making a request
-	s.OnRequest(func(r *colly.Request) {})
-
-	// Start scraping
-	s.Visit(s.url)
 }
 
 func newNaiveScraper() *naiveScraper {
@@ -44,6 +82,7 @@ func newNaiveScraper() *naiveScraper {
 			// colly.AllowedDomains("indeed.com", "uk.indeed.com"),
 			// colly.Debugger(&debug.WebDebugger{}),
 			// colly.AllowURLRevisit(),
+			// colly.Async(true),
 		),
 
 		url: "https://uk.indeed.com/jobs?l=Leeds,+West+Yorkshire",


### PR DESCRIPTION
### added `GoScrape` to the Scraper Interface.

This allows us to send scraper requests to be executed asynchronously, paving the way for a highly parrallel scraper.
For example can use a different apify api key for each worker _(see apify.go)_ , brining the apify indeed actor in house will give us more flexibility.

The naive implementation will still be slow as I don't like the way colly handles it's 'Collectors' I think we can do this better if we built it ourself with raw GoQuery.

### Restructure

Just moved the READMEs around to be more relavent and added a core module that will come in handy later when we setup a messaging system.