### PR TITLE
add interface for a fsm or operator

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,0 +1,3 @@
+module operator
+
+go 1.17

--- a/operator/operator/fsm.go
+++ b/operator/operator/fsm.go
@@ -1,0 +1,39 @@
+package operator
+
+type FSM = FiniteStateMachine
+
+// FiniteStateMachine (or FSM) defines a graph where the 'States' are nodes
+// and 'Processors' the out-edges from a node
+//
+// In the future we can use it however we want, for examle, as a message processing system,
+// or build pipeline
+//
+type FiniteStateMachine interface {
+	AddProcessor(State, ...Processor) FSM
+	Run() error
+}
+
+type State string
+
+type Processor interface {
+	Process(m ...Message)
+}
+
+type Message interface {
+	Evelope() Envelope
+	Payload() Payload
+}
+
+type Envelope interface {
+	Destination() State
+	Metadata() Metadata
+}
+
+type Metadata map[string]string
+
+type Payload interface {
+	Value() interface{}
+	Type() PayloadType
+}
+
+type PayloadType string


### PR DESCRIPTION
## Add the operator module
Will be responsible for allowing each module (scraper, algorithm, backend) to talk with each other.
Adding this operator will decouple each component and make them independent so they can be tested like.  Also simplifies knowledge needed for a new person to get familiar with the system if each component is decoupled.

##### it's just an interface for now... need to be implemented